### PR TITLE
Added basic Helm chart 

### DIFF
--- a/deployments/platformdeployment/Kubernetes/chart/yelb/.helmignore
+++ b/deployments/platformdeployment/Kubernetes/chart/yelb/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deployments/platformdeployment/Kubernetes/chart/yelb/Chart.yaml
+++ b/deployments/platformdeployment/Kubernetes/chart/yelb/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Yelb! The only hub for healthy food recommendations
+name: yelb
+version: 0.1.0

--- a/deployments/platformdeployment/Kubernetes/chart/yelb/templates/NOTES.txt
+++ b/deployments/platformdeployment/Kubernetes/chart/yelb/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "yelb.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "yelb.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "yelb.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "yelb.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/deployments/platformdeployment/Kubernetes/chart/yelb/templates/_helpers.tpl
+++ b/deployments/platformdeployment/Kubernetes/chart/yelb/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "yelb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "yelb.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "yelb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deployments/platformdeployment/Kubernetes/chart/yelb/templates/deployment.yaml
+++ b/deployments/platformdeployment/Kubernetes/chart/yelb/templates/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "yelb.fullname" . }}-ui
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "yelb.fullname" . }}
+        tier: frontend
+        release: {{ .Release.Name }}
+        chart: {{ template "yelb.chart" . }}
+    spec:
+      containers:
+      - name: yelb-ui
+        image:  nomisbeme/yelb-ui:0.3
+        ports:
+        - containerPort: 80
+        env:
+        - name: "APP_SERVER_HOSTNAME"
+          value: {{ template "yelb.fullname" . }}-appserver
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "yelb.fullname" . }}-cache
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "yelb.fullname" . }}
+        tier: cache
+        release: {{ .Release.Name }}
+        chart: {{ template "yelb.chart" . }}
+    spec:
+      containers:
+      - name: redis-server
+        image: redis:4.0.2
+        ports:
+        - containerPort: 6379
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "yelb.fullname" . }}-db
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "yelb.fullname" . }}
+        tier: backenddb
+        release: {{ .Release.Name }}
+        chart: {{ template "yelb.chart" . }}
+    spec:
+      containers:
+      - name: {{ template "yelb.fullname" . }}-db
+        image:  mreferre/yelb-db:0.3
+        ports:
+        - containerPort: 5432
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "yelb.fullname" . }}-appserver
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "yelb.fullname" . }}
+        tier: middletier
+        release: {{ .Release.Name }}
+        chart: {{ template "yelb.chart" . }}
+    spec:
+      containers:
+      - name: {{ template "yelb.fullname" . }}-appserver
+        image:  mreferre/yelb-appserver:0.3
+        ports:
+        - containerPort: 4567
+        env:
+        - name: "RACK_ENV"
+          value: "custom"
+        - name: "APP_SERVER_HOSTNAME"
+          value: {{ template "yelb.fullname" . }}-appserver
+        - name: "REDIS_SERVER_ENDPOINT"
+          value: {{ template "yelb.fullname" . }}-redis-server
+        - name: "YELB_DB_SERVER_ENDPOINT"
+          value: {{ template "yelb.fullname" . }}-db

--- a/deployments/platformdeployment/Kubernetes/chart/yelb/templates/ingress.yaml
+++ b/deployments/platformdeployment/Kubernetes/chart/yelb/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "yelb.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "yelb.name" . }}
+    chart: {{ template "yelb.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/deployments/platformdeployment/Kubernetes/chart/yelb/templates/service.yaml
+++ b/deployments/platformdeployment/Kubernetes/chart/yelb/templates/service.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "yelb.fullname" . }}-ui
+  labels:
+    app: {{ template "yelb.fullname" . }}
+    tier: frontend
+    chart: {{ template "yelb.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: 80
+    name: http
+  selector:
+    app: {{ template "yelb.fullname" . }}
+    tier: frontend
+    release: {{ .Release.Name }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "yelb.fullname" . }}-redis-server
+  labels:
+    app: {{ template "yelb.fullname" . }}
+    tier: cache
+    chart: {{ template "yelb.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+  selector:
+    app: {{ template "yelb.fullname" . }}
+    tier: cache
+    release: {{ .Release.Name }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "yelb.fullname" . }}-db
+  labels:
+    app: {{ template "yelb.fullname" . }}
+    tier: backenddb
+    release: {{ .Release.Name }}
+    chart: {{ template "yelb.chart" . }}
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+  selector:
+    app: {{ template "yelb.fullname" . }}
+    tier: backenddb
+    release: {{ .Release.Name }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "yelb.fullname" . }}-appserver
+  labels:
+    app: {{ template "yelb.fullname" . }}
+    tier: middletier
+    release: {{ .Release.Name }}
+    chart: {{ template "yelb.chart" . }}
+spec:
+  type: ClusterIP
+  ports:
+  - port: 4567
+  selector:
+    app: {{ template "yelb.fullname" . }}
+    tier: middletier
+    release: {{ .Release.Name }}

--- a/deployments/platformdeployment/Kubernetes/chart/yelb/values.yaml
+++ b/deployments/platformdeployment/Kubernetes/chart/yelb/values.yaml
@@ -1,0 +1,45 @@
+# Default values for yelb.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  tag: stable
+  pullPolicy: IfNotPresent
+
+service:
+  type: LoadBalancer
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/deployments/platformdeployment/Kubernetes/yaml/README.md
+++ b/deployments/platformdeployment/Kubernetes/yaml/README.md
@@ -1,0 +1,5 @@
+These configurations had been tested against a local minikube setup.
+
+Ideally they should / could be broken into independent configurations for any given module of the app and composed properly at deployment time. 
+
+This is a work in progress.

--- a/deployments/platformdeployment/Kubernetes/yaml/cnawebapp-loadbalancer.yaml
+++ b/deployments/platformdeployment/Kubernetes/yaml/cnawebapp-loadbalancer.yaml
@@ -1,0 +1,136 @@
+# This should work on Kubernetes deployments that have LoadBalancer support
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-server
+  labels:
+    app: redis-server
+    tier: cache
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+  selector:
+    app: redis-server
+    tier: cache
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yelb-db
+  labels:
+    app: yelb-db
+    tier: backenddb
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+  selector:
+    app: yelb-db
+    tier: backenddb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yelb-appserver
+  labels:
+    app: yelb-appserver
+    tier: middletier
+spec:
+  type: ClusterIP
+  ports:
+  - port: 4567
+  selector:
+    app: yelb-appserver
+    tier: middletier
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yelb-ui
+  labels:
+    app: yelb-ui
+    tier: frontend
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: yelb-ui
+    tier: frontend
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yelb-ui
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: yelb-ui
+        tier: frontend
+    spec:
+      containers:
+      - name: yelb-ui
+        image:  mreferre/yelb-ui:0.3
+        ports:
+        - containerPort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-server
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis-server
+        tier: cache
+    spec:
+      containers:
+      - name: redis-server
+        image: redis:4.0.2
+        ports:
+        - containerPort: 6379
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yelb-db
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: yelb-db
+        tier: backenddb
+    spec:
+      containers:
+      - name: yelb-db
+        image:  mreferre/yelb-db:0.3
+        ports:
+        - containerPort: 5432
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yelb-appserver
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: yelb-appserver
+        tier: middletier
+    spec:
+      containers:
+      - name: yelb-appserver
+        image:  mreferre/yelb-appserver:0.3
+        ports:
+        - containerPort: 4567
+
+

--- a/deployments/platformdeployment/Kubernetes/yaml/cnawebapp-minikube-hostport.yaml
+++ b/deployments/platformdeployment/Kubernetes/yaml/cnawebapp-minikube-hostport.yaml
@@ -1,0 +1,125 @@
+# This should work on an out of the box minikube setup
+# Note: using hostPort is a very bad idea
+# A service for the yelb-ui container is not created because the app is being exposed on the node directly (which is bad)
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-server
+  labels:
+    app: redis-server
+    tier: cache
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+  selector:
+    app: redis-server
+    tier: cache
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yelb-db
+  labels:
+    app: yelb-db
+    tier: backenddb
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+  selector:
+    app: yelb-db
+    tier: backenddb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yelb-appserver
+  labels:
+    app: yelb-appserver
+    tier: middletier
+spec:
+  type: ClusterIP
+  ports:
+  - port: 4567
+  selector:
+    app: yelb-appserver
+    tier: middletier
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yelb-ui
+spec:
+  # with hostPort you can't have more than 1 replica because with minikube you only have 1 worker node
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: yelb-ui
+        tier: frontend
+    spec:
+      containers:
+      - name: yelb-ui
+        image: mreferre/yelb-ui:0.3
+        ports:
+        - containerPort: 80
+          hostPort: 32777 # depending on the minikube driver you use you may be able to even use 80. But something above 32000 seems safer 
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-server
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis-server
+        tier: cache
+    spec:
+      containers:
+      - name: redis-server
+        image: redis:4.0.2
+        ports:
+        - containerPort: 6379
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yelb-db
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: yelb-db
+        tier: backenddb
+    spec:
+      containers:
+      - name: yelb-db
+        image: mreferre/yelb-db:0.3
+        ports:
+        - containerPort: 5432
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yelb-appserver
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: yelb-appserver
+        tier: middletier
+    spec:
+      containers:
+      - name: yelb-appserver
+        image: mreferre/yelb-appserver:0.3
+        ports:
+        - containerPort: 4567
+
+
+
+

--- a/deployments/platformdeployment/Kubernetes/yaml/cnawebapp-minikube-ingress.yaml
+++ b/deployments/platformdeployment/Kubernetes/yaml/cnawebapp-minikube-ingress.yaml
@@ -1,0 +1,154 @@
+# This should work on an out of the box minikube setup 
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-server
+  labels:
+    app: redis-server
+    tier: cache
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+  selector:
+    app: redis-server
+    tier: cache
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yelb-db
+  labels:
+    app: yelb-db
+    tier: backenddb
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+  selector:
+    app: yelb-db
+    tier: backenddb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yelb-appserver
+  labels:
+    app: yelb-appserver
+    tier: middletier
+spec:
+  type: ClusterIP
+  ports:
+  - port: 4567
+  selector:
+    app: yelb-appserver
+    tier: middletier
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yelb-ui
+  labels:
+    app: yelb-ui
+    tier: frontend
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+  selector:
+    app: yelb-ui
+    tier: frontend
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: yelb-ui-ingress
+spec:
+  rules:
+    - host: yelb.mydomain.com
+      http:
+        paths:
+          - path: /
+            backend: 
+              serviceName: yelb-ui
+              servicePort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yelb-ui
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: yelb-ui
+        tier: frontend
+    spec:
+      containers:
+      - name: yelb-ui
+        image: mreferre/yelb-ui:0.3
+        ports:
+        - containerPort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-server
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis-server
+        tier: cache
+    spec:
+      containers:
+      - name: redis-server
+        image: redis:4.0.2
+        ports:
+        - containerPort: 6379
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yelb-db
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: yelb-db
+        tier: backenddb
+    spec:
+      containers:
+      - name: yelb-db
+        image: mreferre/yelb-db:0.3
+        ports:
+        - containerPort: 5432
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yelb-appserver
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: yelb-appserver
+        tier: middletier
+    spec:
+      containers:
+      - name: yelb-appserver
+        image: mreferre/yelb-appserver:0.3
+        ports:
+        - containerPort: 4567
+
+
+
+
+
+
+
+

--- a/deployments/platformdeployment/Kubernetes/yaml/cnawebapp-minikube-nodeport.yaml
+++ b/deployments/platformdeployment/Kubernetes/yaml/cnawebapp-minikube-nodeport.yaml
@@ -1,0 +1,138 @@
+# This should work on an out of the box minikube setup 
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-server
+  labels:
+    app: redis-server
+    tier: cache
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+  selector:
+    app: redis-server
+    tier: cache
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yelb-db
+  labels:
+    app: yelb-db
+    tier: backenddb
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+  selector:
+    app: yelb-db
+    tier: backenddb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yelb-appserver
+  labels:
+    app: yelb-appserver
+    tier: middletier
+spec:
+  type: ClusterIP
+  ports:
+  - port: 4567
+  selector:
+    app: yelb-appserver
+    tier: middletier
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yelb-ui
+  labels:
+    app: yelb-ui
+    tier: frontend
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+    # nodePort: 32777 <- if not specified, the system will generate a nodePort value
+  selector:
+    app: yelb-ui
+    tier: frontend
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yelb-ui
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: yelb-ui
+        tier: frontend
+    spec:
+      containers:
+      - name: yelb-ui
+        image: mreferre/yelb-ui:0.3
+        ports:
+        - containerPort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-server
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis-server
+        tier: cache
+    spec:
+      containers:
+      - name: redis-server
+        image: redis:4.0.2
+        ports:
+        - containerPort: 6379
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yelb-db
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: yelb-db
+        tier: backenddb
+    spec:
+      containers:
+      - name: yelb-db
+        image: mreferre/yelb-db:0.3
+        ports:
+        - containerPort: 5432
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yelb-appserver
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: yelb-appserver
+        tier: middletier
+    spec:
+      containers:
+      - name: yelb-appserver
+        image: mreferre/yelb-appserver:0.3
+        ports:
+        - containerPort: 4567
+
+
+

--- a/yelb-ui/Dockerfile
+++ b/yelb-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.11
+FROM node:8.11
 MAINTAINER massimo@it20.info
 
 WORKDIR /

--- a/yelb-ui/startup.sh
+++ b/yelb-ui/startup.sh
@@ -8,7 +8,7 @@ sed -i -- 's#/usr/share/nginx/html#/clarity-seed/'$UI_ENV'/dist#g' $NGINX_CONF
 # everything that hits /api is proxied to the app server     
 if ! grep -q "location /api" "$NGINX_CONF"; then
 	echo "    location /api {" > /proxycfg.txt
-	echo "        proxy_pass http://yelb-appserver:4567/api;" >> /proxycfg.txt
+	echo "        proxy_pass http://${APP_SERVER_HOSTNAME:-yelb-appserver}:4567/api;" >> /proxycfg.txt
 	# echo "        proxy_set_header Host $host;" >> /proxycfg.tx
 	echo "    }" >> /proxycfg.txt
 	sed --in-place '/server_name  localhost;/ r /proxycfg.txt' $NGINX_CONF

--- a/yelb-ui/startup.sh
+++ b/yelb-ui/startup.sh
@@ -8,7 +8,7 @@ sed -i -- 's#/usr/share/nginx/html#/clarity-seed/'$UI_ENV'/dist#g' $NGINX_CONF
 # everything that hits /api is proxied to the app server     
 if ! grep -q "location /api" "$NGINX_CONF"; then
 	echo "    location /api {" > /proxycfg.txt
-	echo "        proxy_pass http://${APP_SERVER_HOSTNAME:-yelb-appserver}:4567/api;" >> /proxycfg.txt
+	echo "        proxy_pass http://yelb-appserver:4567/api;" >> /proxycfg.txt
 	# echo "        proxy_set_header Host $host;" >> /proxycfg.tx
 	echo "    }" >> /proxycfg.txt
 	sed --in-place '/server_name  localhost;/ r /proxycfg.txt' $NGINX_CONF


### PR DESCRIPTION
Bump node version to 8 to allow build to work with contemporary versions of the dependencies. 
Make the app server hostname an env var (useful for kubernetes deployment, WIP)