### PR TITLE
Pin @types/node to 6.0.42 for yelb-ui

### DIFF
--- a/yelb-ui/clarity-seed-newfiles/package.json
+++ b/yelb-ui/clarity-seed-newfiles/package.json
@@ -39,7 +39,7 @@
     "@angular/compiler-cli": "^4.0.1",
     "@types/core-js": "^0.9.34",
     "@types/jasmine": "~2.2.30",
-    "@types/node": "^6.0.42",
+    "@types/node": "6.0.42",
     "bootstrap": "4.0.0-alpha.5",
     "codelyzer": "~2.0.0-beta.4",
     "enhanced-resolve": "^3.0.0",


### PR DESCRIPTION
Latest versions of Node.js lead to the following exception when building yelb-ui Docker image:
node_modules/@types/node/index.d.ts(20,1): error TS1084: Invalid 'reference' directive syntax.

Pinning to 6.0.42 version (instead of ^) solves the issue.