### PR TITLE
Add Copilot example

### DIFF
--- a/deployments/platformdeployment/AWS/ECS/README.md
+++ b/deployments/platformdeployment/AWS/ECS/README.md
@@ -2,7 +2,7 @@ In this folder there are Cloudformation and CDK artifacts to deploy Yelb.
 
 The CFN template(s) allows to deploy on both Amazon EC2 as well as AWS Fargate on existing cluster and VPCs. 
 
-The CDK code allows to deploy on AWS Fargate only and it creates a dedicated ECS cluster and VPC. 
+The CDK code and the Copilot templates allow to deploy on AWS Fargate only and they create a dedicated ECS cluster and VPC. 
 
 They are provided as basic examples of how to deploy Yelb on ECS. 
 

--- a/deployments/platformdeployment/AWS/ECS/README.md
+++ b/deployments/platformdeployment/AWS/ECS/README.md
@@ -2,7 +2,7 @@ In this folder there are Cloudformation and CDK artifacts to deploy Yelb.
 
 The CFN template(s) allows to deploy on both Amazon EC2 as well as AWS Fargate on existing cluster and VPCs. 
 
-The CDK code and the Copilot templates allow to deploy on AWS Fargate only and they create a dedicated ECS cluster and VPC. 
+The CDK code and the Copilot manifests allow to deploy on AWS Fargate only and they create a dedicated ECS cluster and VPC. 
 
 They are provided as basic examples of how to deploy Yelb on ECS. 
 

--- a/deployments/platformdeployment/AWS/ECS/copilot/.workspace
+++ b/deployments/platformdeployment/AWS/ECS/copilot/.workspace
@@ -1,0 +1,1 @@
+application: yelb

--- a/deployments/platformdeployment/AWS/ECS/copilot/README.md
+++ b/deployments/platformdeployment/AWS/ECS/copilot/README.md
@@ -4,16 +4,22 @@ config (svcname/manifest.yml).
 
 This folder contains the pre-created manifests. When Copilot detects that a service you are trying to create on the CLI already has a corresponding manifest (which matches the name of the service) it will skip the creation of the manifest. This means if you want to fine tune these services, you should tweak the manifests and not the commands below. 
 
-These commands assume you have the Copilot tool installed and you have an AWS CLI profile called `default` already created. Make sure you are running these commands needs to be run from this folder as the commands include relative paths:  
+These commands assume you have the Copilot tool installed and you have an AWS CLI profile called `default` already created. Make sure you are running these commands from the `/deployments/platformdeployment/AWS/ECS` folder because the copilot binary will look for a `copilot` folder.
+
+First initialize the app with this command:
 ```
 $ copilot app init
-
-$ copilot env init --name test-env --default-config —profile default 
-
+```
+Then initialize an environment to deploy the Yelb application:
+```
+$ copilot env init --name yelb-env --default-config —-profile default 
+```
+At this point we are ready to deploy the 4 services that comprise the applicatio:
+```
 $ copilot init --app yelb --name redis-server --image redis:redis:4.0.2 --type "Backend Service" --deploy 
-$ copilot init --app yelb --name yelb-db --dockerfile ../../../../../yelb-db/Dockerfile --type "Backend Service" --deploy 
-$ copilot init --app yelb --name yelb-appserver --dockerfile ../../../../../yelb-appserver/Dockerfile --type "Backend Service" --deploy 
-$ copilot init --app yelb --name yelb-ui --dockerfile ../../../../../yelb-ui/Dockerfile --type "Load Balanced Web Service" --port 80 --deploy
+$ copilot init --app yelb --name yelb-db --dockerfile ../../../../yelb-db/Dockerfile --type "Backend Service" --deploy 
+$ copilot init --app yelb --name yelb-appserver --dockerfile ../../../../yelb-appserver/Dockerfile --type "Backend Service" --deploy 
+$ copilot init --app yelb --name yelb-ui --dockerfile ../../../../yelb-ui/Dockerfile --type "Load Balanced Web Service" --port 80 --deploy
 ```
 
 Once all commands have completed you should see all services:

--- a/deployments/platformdeployment/AWS/ECS/copilot/README.md
+++ b/deployments/platformdeployment/AWS/ECS/copilot/README.md
@@ -1,13 +1,71 @@
 This is a sample which uses [AWS Copilot](https://aws.amazon.com/containers/copilot/) for deploying
 the Yelb application. Each component of Yelb is represented as a separate service in the Copilot
-config (svcname/manifest.yml).
+config (svcname/manifest.yml). 
 
+This folder contains the pre-created manifests. When Copilot detects that a service you are trying to create on the CLI already has a corresponding manifest (which matches the name of the service) it will skip the creation of the manifest. This means if you want to fine tune these services, you should tweak the manifests and not the commands below. 
+
+These commands assume you have the Copilot tool installed and you have an AWS CLI profile called `default` already created. Make sure you are running these commands needs to be run from this folder as the commands include relative paths:  
 ```
-$ copilot svc ls --app yelb
+$ copilot app init
+
+$ copilot env init --name test-env --default-config —profile default 
+
+$ copilot init --app yelb --name redis-server --image redis:redis:4.0.2 --type "Backend Service" --deploy 
+$ copilot init --app yelb --name yelb-db --dockerfile ../../../../../yelb-db/Dockerfile --type "Backend Service" --deploy 
+$ copilot init --app yelb --name yelb-appserver --dockerfile ../../../../../yelb-appserver/Dockerfile --type "Backend Service" --deploy 
+$ copilot init --app yelb --name yelb-ui --dockerfile ../../../../../yelb-ui/Dockerfile --type "Load Balanced Web Service" --port 80 --deploy
+```
+
+Once all commands have completed you should see all services:
+```
+$ copilot svc ls 
 Name                Type
---------------      -------------------------
+----                ----
 redis-server        Backend Service
 yelb-appserver      Backend Service
 yelb-db             Backend Service
 yelb-ui             Load Balanced Web Service
 ```
+
+The `yelb-ui` service is exposed as a `Load Balanced Web Service` type and you can find out the endpoint by "showing" the service itself:
+
+```
+$ copilot svc show --name yelb-ui
+About
+
+  Application       yelb
+  Name              yelb-ui
+  Type              Load Balanced Web Service
+
+Configurations
+
+  Environment       Tasks               CPU (vCPU)          Memory (MiB)        Port
+  -----------       -----               ----------          ------------        ----
+  test              1                   0.25                512                 80
+
+Routes
+
+  Environment       URL
+  -----------       ---
+  test              http://yelb-Publi-1VTBONVYKH6CW-1859885541.us-west-2.elb.amazonaws.com
+
+Service Discovery
+
+  Environment       Namespace
+  -----------       ---------
+  test              yelb-ui.yelb.local:80
+
+Variables
+
+  Name                                Container           Environment         Value
+  ----                                ---------           -----------         -----
+  COPILOT_APPLICATION_NAME            yelb-ui             test                yelb
+  COPILOT_ENVIRONMENT_NAME              "                   "                 test
+  COPILOT_LB_DNS                        "                   "                 yelb-Publi-1VTBONVYKH6CW-1859885541.us-west-2.elb.amazonaws.com
+  COPILOT_SERVICE_DISCOVERY_ENDPOINT    "                   "                 yelb.local
+  COPILOT_SERVICE_NAME                  "                   "                 yelb-ui
+  SEARCH_DOMAIN                         "                   "                 yelb.local
+$ 
+```
+
+Pointing the web browser to the LB endpoint should render the Yelb home page. 

--- a/deployments/platformdeployment/AWS/ECS/copilot/README.md
+++ b/deployments/platformdeployment/AWS/ECS/copilot/README.md
@@ -1,0 +1,13 @@
+This is a sample which uses [AWS Copilot](https://aws.amazon.com/containers/copilot/) for deploying
+the Yelb application. Each component of Yelb is represented as a separate service in the Copilot
+config (svcname/manifest.yml).
+
+```
+$ copilot svc ls --app yelb
+Name                Type
+--------------      -------------------------
+redis-server        Backend Service
+yelb-appserver      Backend Service
+yelb-db             Backend Service
+yelb-ui             Load Balanced Web Service
+```

--- a/deployments/platformdeployment/AWS/ECS/copilot/redis-server/manifest.yml
+++ b/deployments/platformdeployment/AWS/ECS/copilot/redis-server/manifest.yml
@@ -9,7 +9,7 @@ type: Backend Service
 
 image:
   # The name of the Docker image.
-  location: public.ecr.aws/bitnami/redis:4.0
+  location: redis:4.0.2
   # Port exposed through your container to route traffic to it.
   port: 6379
 

--- a/deployments/platformdeployment/AWS/ECS/copilot/redis-server/manifest.yml
+++ b/deployments/platformdeployment/AWS/ECS/copilot/redis-server/manifest.yml
@@ -1,0 +1,34 @@
+# The manifest for the "redis-server" service.
+# Read the full specification for the "Backend Service" type at:
+#  https://aws.github.io/copilot-cli/docs/manifest/backend-service/
+
+# Your service name will be used in naming your resources like log groups, ECS services, etc.
+name: redis-server
+# Your service is reachable at "http://redis-server.${COPILOT_SERVICE_DISCOVERY_ENDPOINT}:6379" but is not public.
+type: Backend Service
+
+image:
+  # The name of the Docker image.
+  location: public.ecr.aws/bitnami/redis:4.0
+  # Port exposed through your container to route traffic to it.
+  port: 6379
+
+# Number of CPU units for the task.
+cpu: 256
+# Amount of memory in MiB used by the task.
+memory: 512
+# Number of tasks that should be running in your service.
+count: 1
+
+# Optional fields for more advanced use-cases.
+#
+variables:
+  ALLOW_EMPTY_PASSWORD: yes
+
+#secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
+#  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM      parameter.
+
+# You can override any of the values defined above by environment.
+#environments:
+#  test:
+#    count: 2               # Number of tasks to run for the "test" environment.

--- a/deployments/platformdeployment/AWS/ECS/copilot/yelb-appserver/manifest.yml
+++ b/deployments/platformdeployment/AWS/ECS/copilot/yelb-appserver/manifest.yml
@@ -1,0 +1,35 @@
+# The manifest for the "yelb-appserver" service.
+# Read the full specification for the "Backend Service" type at:
+#  https://aws.github.io/copilot-cli/docs/manifest/backend-service/
+
+# Your service name will be used in naming your resources like log groups, ECS services, etc.
+name: yelb-appserver
+# Your service is reachable at "http://yelb-appserver.${COPILOT_SERVICE_DISCOVERY_ENDPOINT}:5432" but is not public.
+type: Backend Service
+
+image:
+  # Docker build arguments.
+  # For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/backend-service/#image-build
+  build: ../../../../yelb-appserver/Dockerfile
+  # Port exposed through your container to route traffic to it.
+  port: 4567
+
+# Number of CPU units for the task.
+cpu: 512
+# Amount of memory in MiB used by the task.
+memory: 2048
+# Number of tasks that should be running in your service.
+count: 1
+
+# Optional fields for more advanced use-cases.
+#
+variables:
+  SEARCH_DOMAIN: yelb.local
+
+#secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
+#  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM      parameter.
+
+# You can override any of the values defined above by environment.
+#environments:
+#  test:
+#    count: 2               # Number of tasks to run for the "test" environment.

--- a/deployments/platformdeployment/AWS/ECS/copilot/yelb-db/manifest.yml
+++ b/deployments/platformdeployment/AWS/ECS/copilot/yelb-db/manifest.yml
@@ -1,0 +1,35 @@
+# The manifest for the "yelb-db" service.
+# Read the full specification for the "Backend Service" type at:
+#  https://aws.github.io/copilot-cli/docs/manifest/backend-service/
+
+# Your service name will be used in naming your resources like log groups, ECS services, etc.
+name: yelb-db
+# Your service is reachable at "http://yelb-db.${COPILOT_SERVICE_DISCOVERY_ENDPOINT}:5432" but is not public.
+type: Backend Service
+
+image:
+  # Docker build arguments.
+  # For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/backend-service/#image-build
+  build: ../../../../yelb-db/Dockerfile
+  # Port exposed through your container to route traffic to it.
+  port: 5432
+
+# Number of CPU units for the task.
+cpu: 512
+# Amount of memory in MiB used by the task.
+memory: 2048
+# Number of tasks that should be running in your service.
+count: 1
+
+# Optional fields for more advanced use-cases.
+#
+#variables:                    # Pass environment variables as key value pairs.
+#  LOG_LEVEL: info
+
+#secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
+#  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM      parameter.
+
+# You can override any of the values defined above by environment.
+#environments:
+#  test:
+#    count: 2               # Number of tasks to run for the "test" environment.

--- a/deployments/platformdeployment/AWS/ECS/copilot/yelb-ui/manifest.yml
+++ b/deployments/platformdeployment/AWS/ECS/copilot/yelb-ui/manifest.yml
@@ -1,0 +1,45 @@
+# The manifest for the "yelb-ui" service.
+# Read the full specification for the "Load Balanced Web Service" type at:
+#  https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/
+
+# Your service name will be used in naming your resources like log groups, ECS services, etc.
+name: yelb-ui
+# The "architecture" of the service you're running.
+type: Load Balanced Web Service
+
+image:
+  # Docker build arguments.
+  # For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#image-build
+  build: ../../../../yelb-ui/Dockerfile
+  # Port exposed through your container to route traffic to it.
+  port: 80
+
+http:
+  # Requests to this path will be forwarded to your service. 
+  # To match all requests you can use the "/" path. 
+  path: '/'
+  # You can specify a custom health check path. The default is "/".
+  # For additional configuration: https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#http-healthcheck
+  # healthcheck: '/'
+  # You can enable sticky sessions.
+  # stickiness: true
+
+# Number of CPU units for the task.
+cpu: 256
+# Amount of memory in MiB used by the task.
+memory: 512
+# Number of tasks that should be running in your service.
+count: 1
+
+# Optional fields for more advanced use-cases.
+#
+variables:
+  SEARCH_DOMAIN: yelb.local
+#
+#secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
+#  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
+
+# You can override any of the values defined above by environment.
+#environments:
+#  test:
+#    count: 2               # Number of tasks to run for the "test" environment.


### PR DESCRIPTION
Contains example for using AWS Copilot to deploy the Yelb application.